### PR TITLE
Add TCP listener for Markdown strings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Simai"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "notify",
  "serde",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,9 +1,9 @@
-// Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
+use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{path::Path, sync::mpsc};
@@ -26,6 +26,12 @@ struct TargetFile {
 struct UpdateFile {
     path: String,
     content: String,
+}
+
+#[derive(Deserialize)]
+struct TcpConfig {
+    address: String,
+    port: u16,
 }
 
 fn start_watch(
@@ -143,6 +149,50 @@ fn start_watch(
     Ok(())
 }
 
+fn handle_client(stream: TcpStream, app_handle: Arc<Mutex<AppHandle>>) {
+    let mut buffer = String::new();
+    let mut reader = std::io::BufReader::new(stream);
+    reader.read_to_string(&mut buffer).unwrap();
+
+    let emit_object = UpdateFile {
+        path: "tcp".to_string(),
+        content: buffer.clone(),
+    };
+
+    let app_handle_lock = app_handle.lock().unwrap();
+    app_handle_lock.emit_all("update_md_tcp", emit_object).unwrap();
+    drop(app_handle_lock);
+}
+
+fn start_tcp_server(
+    app_handle: Arc<Mutex<AppHandle>>,
+    stop_rx: Arc<Mutex<mpsc::Receiver<()>>>,
+    address: &str,
+    port: u16,
+) {
+    let listener = TcpListener::bind(format!("{}:{}", address, port)).unwrap();
+    println!("TCP server listening on {}:{}", address, port);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let app_handle = Arc::clone(&app_handle);
+                thread::spawn(move || {
+                    handle_client(stream, app_handle);
+                });
+            }
+            Err(e) => {
+                println!("Error: {}", e);
+            }
+        }
+
+        if stop_rx.lock().unwrap().try_recv().is_ok() {
+            println!("Shutting down TCP server.");
+            break;
+        }
+    }
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
@@ -154,6 +204,10 @@ fn main() {
             // シミュレーション用の送受信チャンネル
             let (stop_tx, stop_rx) = std::sync::mpsc::channel();
             let stop_rx = Arc::new(Mutex::new(stop_rx));
+
+            // TCP server stop channel
+            let (stop_tcp_tx, stop_tcp_rx) = std::sync::mpsc::channel();
+            let stop_tcp_rx = Arc::new(Mutex::new(stop_tcp_rx));
 
             {
                 let app_handle = Arc::clone(&app_handle);
@@ -174,9 +228,12 @@ fn main() {
             // グローバルリスナーの設定
             {
                 let app_handle = Arc::clone(&app_handle);
+                let stop_rx = Arc::clone(&stop_rx);
+                let stop_tcp_tx = stop_tcp_tx.clone();
                 app.listen_global("start_watch_md", move |event| {
                     let app_handle = Arc::clone(&app_handle);
                     let stop_rx = Arc::clone(&stop_rx);
+                    let stop_tcp_tx = stop_tcp_tx.clone();
                     println!("start_watch_md");
                     thread::spawn(move || {
                         let stop_rx_lock = stop_rx.lock().unwrap();
@@ -184,6 +241,7 @@ fn main() {
                         let target_file = serde_json::from_str::<TargetFile>(&file_path).unwrap();
                         start_watch(app_handle, &target_file.path, &stop_rx_lock, "update_md")
                             .unwrap();
+                        stop_tcp_tx.send(()).unwrap();
                     });
                 });
             }
@@ -197,15 +255,18 @@ fn main() {
             {
                 let app_handle = Arc::clone(&app_handle);
                 let stop_rx_css = Arc::new(Mutex::new(stop_rx_css));
+                let stop_tcp_tx = stop_tcp_tx.clone();
                 app.listen_global("start_watch_css", move |event| {
                     let app_handle = Arc::clone(&app_handle);
                     let stop_rx_css = Arc::clone(&stop_rx_css);
+                    let stop_tcp_tx = stop_tcp_tx.clone();
                     thread::spawn(move || {
                         let stop_rx_lock = stop_rx_css.lock().unwrap();
                         let file_path = event.payload().unwrap().to_string();
                         let target_file = serde_json::from_str::<TargetFile>(&file_path).unwrap();
                         start_watch(app_handle, &target_file.path, &stop_rx_lock, "update_css")
                             .unwrap();
+                        stop_tcp_tx.send(()).unwrap();
                     });
                 });
 
@@ -214,6 +275,29 @@ fn main() {
                     println!("stoped.");
                 });
             }
+
+            // Start TCP server
+            {
+                let app_handle = Arc::clone(&app_handle);
+                let stop_tcp_rx = Arc::clone(&stop_tcp_rx);
+                thread::spawn(move || {
+                    start_tcp_server(app_handle, stop_tcp_rx, "127.0.0.1", 7878);
+                });
+            }
+
+            app.listen_global("start_tcp_listener", move |event| {
+                let app_handle = Arc::clone(&app_handle);
+                let stop_tcp_rx = Arc::clone(&stop_tcp_rx);
+                let tcp_config: TcpConfig = serde_json::from_str(event.payload().unwrap()).unwrap();
+                thread::spawn(move || {
+                    start_tcp_server(app_handle, stop_tcp_rx, &tcp_config.address, tcp_config.port);
+                });
+            });
+
+            app.listen_global("stop_tcp_listener", move |_| {
+                stop_tcp_tx.send(()).unwrap();
+                println!("TCP listener stopped.");
+            });
 
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -278,15 +278,6 @@ fn main() {
                 });
             }
 
-            // Start TCP server
-            {
-                let app_handle = Arc::clone(&app_handle);
-                let stop_tcp_rx = Arc::clone(&stop_tcp_rx);
-                thread::spawn(move || {
-                    start_tcp_server(app_handle, "127.0.0.1".to_string(), 7878);
-                });
-            }
-
             app.listen_global("start_tcp_listener", move |event| {
                 let app_handle = Arc::clone(&app_handle);
                 let stop_tcp_rx = Arc::clone(&stop_tcp_rx);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,7 +172,7 @@ function App() {
   const handleToggleChange = async () => {
     setIsTcpListener(!isTcpListener);
     if (isTcpListener) {
-      await emit('stop_tcp_listener', {});
+      await emit('stop_tcp_listener', { address: tcpAddress, port: tcpPort });
     } else {
       await emit('start_tcp_listener', { address: tcpAddress, port: tcpPort });
       if (store) {


### PR DESCRIPTION
Related to #5

Add TCP server to receive Markdown strings and integrate with existing file handling logic.

* Add TCP server in `src-tauri/src/main.rs` to listen for incoming Markdown strings.
* Process received Markdown strings and emit an event to the frontend.
* Add logic to toggle between file watcher and TCP listener based on a flag.
* Stop TCP listener when file watcher is active and vice versa.
* Add logic to handle listen address and port from the frontend.
* Add event listeners in `src/App.tsx` to update Markdown content when TCP event is received.
* Add a toggle switch in the UI to switch between file watcher and TCP listener.
* Add input fields for listen address and port in the UI.
* Save the listen address and port to Tauri's Store.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mikoto2000/Simai/pull/6?shareId=51ff3cd4-466c-48ad-bd1e-09d631600485).